### PR TITLE
footer image always takes up max width, and delivery and service text…

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -35,7 +35,7 @@ function Footer() {
         </div>
       </section>
       <section id="footer-bottom">
-        <img src="/footer.png" alt="Drawing of Charles Street Supply Storefront" />
+        <img id="footer-image" src="/footer.png" alt="Drawing of Charles Street Supply Storefront" />
         <img
           ref={scooterRef}
           id="scooter"

--- a/src/style.scss
+++ b/src/style.scss
@@ -248,6 +248,7 @@ ul {
   padding: 15px;
   margin: 0 auto;
   height: 40vh;
+  max-height: 300px;
 }
 
 #services-overview h2 {
@@ -466,6 +467,10 @@ ul {
   overflow: hidden;
   display: flex;
   justify-content: center;
+}
+
+#footer-image {
+  width: 100vw;
 }
 
 #footer-bottom img[alt*="Charles Street Supply"] {


### PR DESCRIPTION
<img width="1083" height="325" alt="image" src="https://github.com/user-attachments/assets/fd51060f-6d5b-4d6f-84e5-77ac4c6b719f" />
<img width="1102" height="747" alt="image" src="https://github.com/user-attachments/assets/2780a510-f0dd-4c4c-b7b8-e0c8c67b9cf3" />
